### PR TITLE
Fix broken image registry/name/tag parsing for custom images

### DIFF
--- a/src/components/backend-ai-resource-monitor.ts
+++ b/src/components/backend-ai-resource-monitor.ts
@@ -1583,12 +1583,24 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
         this.supports[supportsKey].push(item.tag);
         let imageName: string;
         let specs: string[] = item.name.split('/');
-        if (specs.length == 2) {
-          imageName = specs[1];
+        if (specs.length === 1) {
+          imageName = specs[0];
         } else {
-          imageName = specs[2];
+          imageName = specs[1];
         }
-        this.supportImages[supportsKey] = this.imageInfo[imageName];
+        this.supportImages[supportsKey] = this.imageInfo[imageName] || {
+          name: 'Custom Environments',
+          description: 'Custom-built images.',
+          group: 'Custom Environments',
+          tags: [],
+          label: [
+            {
+              'category': 'Custom',
+              'tag': 'Custom',
+              'color': 'black'
+            }
+          ]
+        };
         // Fallback routine if image has no metadata
         if (!('group' in this.supportImages[supportsKey])) {
           this.supportImages[supportsKey].group = 'Custom Environments';

--- a/src/components/backend-ai-session-list.ts
+++ b/src/components/backend-ai-session-list.ts
@@ -371,7 +371,7 @@ export default class BackendAiSessionList extends BackendAIPage {
         Object.keys(sessions).map((objectKey, index) => {
           let session = sessions[objectKey];
           let occupied_slots = JSON.parse(session.occupied_slots);
-          const kernelImage = sessions[objectKey].lang.split('/')[2];
+          const kernelImage = sessions[objectKey].lang.split('/')[2] || sessions[objectKey].lang.split('/')[1];
           sessions[objectKey].cpu_slot = parseInt(occupied_slots.cpu);
           sessions[objectKey].mem_slot = parseFloat(window.backendaiclient.utils.changeBinaryUnit(occupied_slots.mem, 'g'));
           sessions[objectKey].mem_slot = sessions[objectKey].mem_slot.toFixed(2);
@@ -407,14 +407,13 @@ export default class BackendAiSessionList extends BackendAIPage {
           }
           sessions[objectKey].kernel_image = kernelImage;
           sessions[objectKey].sessionTags = this._getKernelInfo(session.lang);
-          let tag = session.lang.split(':')[1];
+          const specs = session.lang.split('/');
+          const tag = specs[specs.length - 1].split(':')[1]
           let tags = tag.split('-');
           if (tags[1] !== undefined) {
             sessions[objectKey].baseversion = tags[0];
             sessions[objectKey].baseimage = tags[1];
-            if (tags[2] !== undefined) {
-              sessions[objectKey].additional_reqs = tags.slice(1, tags.length).map((tag) => tag.toUpperCase());
-            }
+            sessions[objectKey].additional_reqs = tags.slice(1, tags.length).map((tag) => tag.toUpperCase());
           } else {
             sessions[objectKey].baseversion = sessions[objectKey].tag;
           }
@@ -464,12 +463,26 @@ export default class BackendAiSessionList extends BackendAIPage {
   _getKernelInfo(lang) {
     let tags: any = [];
     if (lang === undefined) return [];
-    let name = lang.split('/')[2].split(':')[0];
+    const specs = lang.split('/');
+    let name = (specs[2] || specs[1]).split(':')[0];
     if (name in this.kernel_labels) {
       tags.push(this.kernel_labels[name]);
     } else {
+      const imageParts = lang.split('/');
+      // const registry = imageParts[0]; // hide registry (ip of docker registry is exposed)
+      let namespace;
+      let langName;
+      if (imageParts.length === 3) {
+        namespace = imageParts[1];
+        langName = imageParts[2];
+      } else {
+        namespace = '';
+        langName = imageParts[1];
+      }
+      langName = langName.split(':')[0]
+      langName = namespace ? namespace + '/' + langName : langName;
       tags.push([
-        {'category': 'Env', 'tag': lang, 'color': 'green'}
+        {'category': 'Env', 'tag': `${langName}`, 'color': 'lightgrey'}
       ]);
     }
     return tags;
@@ -956,13 +969,13 @@ export default class BackendAiSessionList extends BackendAIPage {
           <div>${rowData.item[this.sessionNameField]}</div>
           ${rowData.item.sessionTags ? rowData.item.sessionTags.map(item => html`
             ${item.map(item => {
-        if (item.category === 'Env') {
-          item.category = item.tag;
-        }
-        if (rowData.item.baseversion) {
-          item.tag = rowData.item.baseversion;
-        }
-        return html`
+              if (item.category === 'Env') {
+                item.category = item.tag;
+                if (rowData.item.baseversion) {
+                  item.tag = rowData.item.baseversion;
+                }
+              }
+              return html`
                 <lablup-shields app="${item.category === undefined ? '' : item.category}" color="${item.color}" description="${item.tag}"></lablup-shields>
               `;
             })}
@@ -972,7 +985,7 @@ export default class BackendAiSessionList extends BackendAIPage {
               ${rowData.item.additional_reqs.map((tag) => {
                 return html`
                   <lablup-shields app="" color="green" description="${tag}"></lablup-shields>
-                `
+                `;
               })}
             </div>
           ` : html``}


### PR DESCRIPTION
* Fix broken image parsing for images without namespace (eg: `registry.test.io/gpp:test-t114`).
* Handle registry with port number. For example, now it is possible to correctly parse a registry like `127.0.0.1:8888`.
* Add default image information for custom images which are not registered in `image_metadata.json`.
* Fix version number is displayed twice for NGC images.
* Hide registry text from session info since it may expose the IP address of private docker registry.
* Display image namespace, if exists, of custom a image.
* I set custom image's version string color with grey.

Before this PR:
![image](https://user-images.githubusercontent.com/7539358/73046060-da414480-3eb3-11ea-9405-0b2b13caea60.png)

After this PR:
![image](https://user-images.githubusercontent.com/7539358/73046100-0b217980-3eb4-11ea-93e9-146df31f5071.png)

