### PR TITLE
style: larger home folder icon in folder explorer path navigator

### DIFF
--- a/src/components/backend-ai-storage-list.ts
+++ b/src/components/backend-ai-storage-list.ts
@@ -225,6 +225,11 @@ export default class BackendAiStorageList extends BackendAIPage {
           font-size: 16px;
         }
 
+        .breadcrumb mwc-icon-button {
+          --mdc-icon-size: 20px;
+          --mdc-icon-button-size: 22px;
+        }
+
         mwc-textfield {
           width: 100%;
           --mdc-theme-primary: #242424;
@@ -450,15 +455,22 @@ export default class BackendAiStorageList extends BackendAIPage {
           </h3>
 
           <div class="breadcrumb">
-          ${this.explorer.breadcrumb ? html`
-          <ul>
-              ${this.explorer.breadcrumb.map(item => html`
-               <li>
-                 <a outlined class="goto" path="item" @click="${(e) => this._gotoFolder(e)}" dest="${item}">${item}</a>
-               </li>
-              `)}
-          </ul>
-          ` : html``}
+            ${this.explorer.breadcrumb ? html`
+              <ul>
+                ${this.explorer.breadcrumb.map(item => html`
+                  <li>
+                    ${item === '.' ? html`
+                      <mwc-icon-button
+                        icon="folder_open" dest="${item}"
+                        @click="${(e) => this._gotoFolder(e)}"
+                      ></mwc-icon-button>
+                    ` : html`
+                      <a outlined class="goto" path="item" @click="${(e) => this._gotoFolder(e)}" dest="${item}">${item}</a>
+                    `}
+                  </li>
+                `)}
+              </ul>
+            ` : html``}
           </div>
           <div class="horizontal layout folder-action-buttons">
             <wl-button outlined class="multiple-action-buttons" @click="${() => this._openDeleteMultipleFileDialog()}" style="display:none;">


### PR DESCRIPTION
In folder explorer dialog, there is a folder navigation bar over UPLOAD FILES and NEW FOLDER icons. The home folder is represented here as dot (`.`), and it is so small to click.

This pull-request simply changed the dot (`.`) into a larger folder icon.

before:
![image](https://user-images.githubusercontent.com/7539358/77376031-9a62e480-6db2-11ea-8d75-e4feed85ae93.png)

after:
![image](https://user-images.githubusercontent.com/7539358/77376180-02192f80-6db3-11ea-98a2-0fbf4d5e1ec0.png)
