### PR TITLE
fix: explicitly set cpu/mem values for corresponding components

### DIFF
--- a/src/components/backend-ai-resource-monitor.ts
+++ b/src/components/backend-ai-resource-monitor.ts
@@ -46,6 +46,7 @@ import {
 @customElement("backend-ai-resource-monitor")
 export default class BackendAiResourceMonitor extends BackendAIPage {
   @property({type: Boolean}) is_connected = false;
+  @property({type: Boolean}) enableLaunchButton = false;
   @property({type: String}) direction = "horizontal";
   @property({type: String}) location = '';
   @property({type: Object}) supports = Object();
@@ -617,9 +618,11 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
     if (typeof globalThis.backendaiclient === 'undefined' || globalThis.backendaiclient === null || globalThis.backendaiclient.ready === false) {
       document.addEventListener('backend-ai-connected', () => {
         this.is_connected = true;
+        setTimeout(() => {this.enableLaunchButton = true}, 1000);
       }, true);
     } else {
       this.is_connected = true;
+      setTimeout(() => {this.enableLaunchButton = true}, 1000);
     }
   }
 
@@ -1249,7 +1252,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
     if (this.aggregate_updating === true) {
       return;
     }
-    if (Date.now() - this.lastQueryTime < 2000) {
+    if (Date.now() - this.lastQueryTime < 1000) {
       return;
     }
     //console.log('aggregate from:', from);
@@ -1972,6 +1975,8 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
   }
 
   _updateResourceIndicator(cpu, mem, gpu_type, gpu_value) {
+    this.shadowRoot.querySelector('#cpu-resource').value = cpu;
+    this.shadowRoot.querySelector('#mem-resource').value = mem;
     this.shadowRoot.querySelector('#gpu-resource').value = gpu_value;
     this.shadowRoot.querySelector('#shmem-resource').value = this.shmem_request;
 
@@ -2296,7 +2301,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
           </div>
         </div>
         <div class="layout vertical" style="align-self: center;">
-          <wl-button ?disabled="${!this.is_connected}" class="fg red" id="launch-session" ?fab=${this.direction === 'vertical'} outlined @click="${() => this._launchSessionDialog()}">
+          <wl-button ?disabled="${!this.enableLaunchButton}" class="fg red" id="launch-session" ?fab=${this.direction === 'vertical'} outlined @click="${() => this._launchSessionDialog()}">
             <wl-icon>add</wl-icon>
             ${_t("session.launcher.Start")}
           </wl-button>

--- a/src/components/backend-ai-resource-preset-list.ts
+++ b/src/components/backend-ai-resource-preset-list.ts
@@ -519,7 +519,7 @@ class BackendAiResourcePresetList extends BackendAIPage {
       return;
     }
     let input = this._readResourcePresetInput();
-    if (input.shared_memory >= mem) {
+    if (parseInt(input.shared_memory) >= parseInt(mem)) {
       this.notification.text = 'Memory should be larger than shared memory';
       this.notification.show();
       return;


### PR DESCRIPTION
This PR resolves https://github.com/lablup/backend.ai-console/issues/555.

* Explicitly set cpu/mem values for corresponding components while updating resource indicator.
* Fix a bug that maxmum value of # of sessions is set to zero in initial opening of session launch dialog.
  - Disable session launch button for 1 second. Without this waiting, `_aggregateResourceUse` may not be eecuted due to `lastQueryTime` block.
  - Reduce query interval of `_aggregateResourceuse` from 2 s to 1 s to quickly enable session launch button.
* Fix a bug that shared memory sometimes cannot be set in resource preset creation / modification.
  - e.g.: It was not possible to set 2 g of shared memory for 10 g of memory.
  - `"2g" > "10g"` is judged as `true`, so error message raised that states shared memory cannot be greater than main memory.

Metric calculation after opening session launch dialog is highly asynchrounous and fragile. This PR works okay in my test environment, but it needs to be tested thoroughly in other environments.
