### PR TITLE
bugfix: error when creating resource preset

### DIFF
--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -387,7 +387,11 @@
     "ResourcePreset": "Resource Preset",
     "CreateResourcePreset": "Create Resource Preset",
     "PresetName": "Preset Name",
-    "AboutToDeletePreset": "You are about to delete this preset:"
+    "AboutToDeletePreset": "You are about to delete this preset:",
+    "NoPresetName": "Input preset name",
+    "MemoryShouldBeLargerThanSHMEM": "Memory should be larger than shared memory",
+    "Created": "Resource preset created",
+    "Updated": "Resource preset updated"
   },
   "usersettings": {
     "General": "General",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -385,7 +385,11 @@
     "ResourcePreset": "자원 프리셋",
     "CreateResourcePreset": "자원 프리셋 생성",
     "PresetName": "자원 프리셋 이름",
-    "AboutToDeletePreset": "아래의 자원 프리셋을 삭제하려고 합니다:"
+    "AboutToDeletePreset": "아래의 자원 프리셋을 삭제하려고 합니다:",
+    "NoPresetName": "자원 프리셋의 이름을 입력하십시오",
+    "MemoryShouldBeLargerThanSHMEM": "메모리는 공유메모리보다 커야 합니다",
+    "Created": "자원 프리셋이 생성되었습니다",
+    "Updated": "자원 프리셋에 수정되었습니다"
   },
   "usersettings": {
     "General": "일반",

--- a/src/components/backend-ai-resource-preset-list.ts
+++ b/src/components/backend-ai-resource-preset-list.ts
@@ -3,7 +3,7 @@
  Copyright (c) 2015-2020 Lablup Inc. All rights reserved.
  */
 
-import {translate as _t} from "lit-translate";
+import {get as _text, translate as _t} from "lit-translate";
 import {css, customElement, html, property} from "lit-element";
 import {BackendAIPage} from './backend-ai-page';
 
@@ -499,19 +499,19 @@ class BackendAiResourcePresetList extends BackendAIPage {
     const wrapper = v => v !== undefined && v.includes('Unlimited') ? 'Infinity' : v;
     const mem = wrapper(this.shadowRoot.querySelector('#ram-resource').value + 'g');
     if (!name) {
-      this.notification.text = 'No preset name';
+      this.notification.text = _text('resourcePreset.NoPresetName');
       this.notification.show();
       return;
     }
     let input = this._readResourcePresetInput();
     if (parseInt(input.shared_memory) >= parseInt(mem)) {
-      this.notification.text = 'Memory should be larger than shared memory';
+      this.notification.text = _text('resourcePreset.MemoryShouldBeLargerThanSHMEM');
       this.notification.show();
       return;
     }
     globalThis.backendaiclient.resourcePreset.mutate(name, input).then(response => {
       this.shadowRoot.querySelector('#modify-template-dialog').hide();
-      this.notification.text = "Resource preset successfully updated.";
+      this.notification.text = _text('resourcePreset.Updated');
       this.notification.show();
       this._refreshTemplateData();
     }).catch(err => {
@@ -586,12 +586,12 @@ class BackendAiResourcePresetList extends BackendAIPage {
     let sharedMemory = this.shadowRoot.querySelector('#create-shmem-resource').value;
     if (sharedMemory) sharedMemory = sharedMemory + 'g';
     if (!preset_name) {
-      this.notification.text = 'No preset name';
+      this.notification.text = _text('resourcePreset.NoPresetName');
       this.notification.show();
       return;
     }
-    if (sharedMemory >= mem) {
-      this.notification.text = 'Memory should be larger than shared memory';
+    if (parseInt(sharedMemory) >= parseInt(mem)) {
+      this.notification.text = _text('resourcePreset.MemoryShouldBeLargerThanSHMEM');
       this.notification.show();
       return;
     }
@@ -613,7 +613,7 @@ class BackendAiResourcePresetList extends BackendAIPage {
       .then(res => {
         this.shadowRoot.querySelector('#create-preset-dialog').hide();
         if (res.create_resource_preset.ok) {
-          this.notification.text = "Resource preset successfully created";
+          this.notification.text = _text('resourcePreset.Created');
           this.refresh();
 
           // reset values


### PR DESCRIPTION
This PR resolves #626.

* During creation, memory and shared memory values are compared as string, like `"1g" > "11g"`, which is evaluated as `true`. This PR fixed it to `parseInt` before comparison.
* Add more i18n support in creating/updating resource preset.