### PR TITLE
Feature/add monthly usage panel on statistics page #627

### DIFF
--- a/src/components/backend-ai-chart.ts
+++ b/src/components/backend-ai-chart.ts
@@ -136,7 +136,7 @@ export default class BackendAIChart extends LitElement {
             },
             font: function (context) {
               let width = context.chart.width;
-              let size = Math.round(width / 64);
+              let size = Math.round(width / 64) < 12 ? Math.round(width / 64) : 12;
               return {
                 size: size,
               };
@@ -159,7 +159,7 @@ export default class BackendAIChart extends LitElement {
             },
             font: function (context) {
               let height = context.chart.height;
-              let size = Math.round(height / 16);
+              let size = Math.round(height / 16) < 12 ? Math.round(height / 16) : 12;
               return {
                 size: size,
               };

--- a/src/components/backend-ai-monthly-usage-panel.ts
+++ b/src/components/backend-ai-monthly-usage-panel.ts
@@ -6,7 +6,6 @@
 import {css, customElement, html, LitElement, property} from "lit-element";
 
 import 'weightless/title';
-import format from 'date-fns/format';
 
 import {
   IronFlex,
@@ -25,11 +24,11 @@ import {
 @customElement("backend-ai-monthly-usage-panel")
 export default class BackendAIMonthlyUsagePanel extends LitElement {
   @property({type: Number}) num_sessions = 0;
-  @property({type: Date}) used_time = '00시간 00분';
-  @property({type: Date}) cpu_used_time = '00시간 00분';
-  @property({type: Date}) gpu_used_time = '00시간 00분';
-  @property({type: String}) disk_used = '0GB';
-  @property({type: String}) traffic_used = '0GB';
+  @property({type: String}) used_time = '0:00:00.00';
+  @property({type: String}) cpu_used_time = '0:00:00.00';
+  @property({type: String}) gpu_used_time = '0:00:00.00';
+  @property({type: Number}) disk_used = 0;
+  @property({type: Number}) traffic_used = 0;
 
   constructor() {
     super();
@@ -65,9 +64,24 @@ export default class BackendAIMonthlyUsagePanel extends LitElement {
   }
 
   formatting() {
-    this.used_time = format(new Date(this.used_time), 'HH시간 mm분');
-    this.cpu_used_time = format(new Date(this.cpu_used_time), 'HH시간 mm분');
-    this.gpu_used_time = format(new Date(this.gpu_used_time), 'HH시간 mm분');
+    this.used_time = this.usedTimeFormatting(this.used_time);
+    this.cpu_used_time = this.usedTimeFormatting(this.cpu_used_time);
+    this.gpu_used_time = this.usedTimeFormatting(this.gpu_used_time);
+
+    this.disk_used = Math.floor(this.disk_used / (1024 * 1024 * 1024)); // bytes to GB
+    this.traffic_used = Math.floor(this.traffic_used / (1024 * 1024));  // bytes to MB
+  }
+
+  /**
+   * @param {String} t - [days]:[hours]:[minutes].[seconds]
+   * */
+  usedTimeFormatting(t) {
+    let days = parseInt(t.substring(0, t.indexOf(':')));
+    let hours = parseInt(t.substring(t.indexOf(':') + 1, t.lastIndexOf(':')));
+    let minutes = t.substring(t.lastIndexOf(':') + 1, t.indexOf('.'));
+    hours = days * 24 + hours;
+
+    return hours + '시간' + minutes + '분';
   }
 
   render() {
@@ -93,11 +107,11 @@ export default class BackendAIMonthlyUsagePanel extends LitElement {
             <span class="desc">GPU 사용량</span>
           </div>
           <div class="vertical center layout">
-            <span class="value">${this.disk_used}</span>
+            <span class="value">${this.disk_used}GB</span>
             <span class="desc">디스크 사용량</span>
           </div>
           <div class="vertical center layout">
-            <span class="value">${this.traffic_used}</span>
+            <span class="value">${this.traffic_used}MB</span>
             <span class="desc">트래픽 사용량</span>
           </div>
         </div>

--- a/src/components/backend-ai-monthly-usage-panel.ts
+++ b/src/components/backend-ai-monthly-usage-panel.ts
@@ -1,0 +1,113 @@
+/**
+ @license
+ Copyright (c) 2015-2020 Lablup Inc. All rights reserved.
+ */
+
+import {css, customElement, html, LitElement, property} from "lit-element";
+
+import 'weightless/title';
+import format from 'date-fns/format';
+
+import {
+  IronFlex,
+  IronFlexAlignment,
+  IronFlexFactors,
+  IronPositioning
+} from "../plastics/layout/iron-flex-layout-classes";
+
+/**
+ Backend.AI Monthly Usage Panel
+
+ @group Backend.AI Console
+ @element backend-ai-monthly-usage-panel
+ */
+
+@customElement("backend-ai-monthly-usage-panel")
+export default class BackendAIMonthlyUsagePanel extends LitElement {
+  @property({type: Number}) num_sessions = 0;
+  @property({type: Date}) used_time = '00시간 00분';
+  @property({type: Date}) cpu_used_time = '00시간 00분';
+  @property({type: Date}) gpu_used_time = '00시간 00분';
+  @property({type: String}) disk_used = '0GB';
+  @property({type: String}) traffic_used = '0GB';
+
+  constructor() {
+    super();
+  }
+
+  static get styles() {
+    return [
+      IronFlex,
+      IronFlexAlignment,
+      IronFlexFactors,
+      IronPositioning,
+      // language=CSS
+      css`
+        wl-card {
+          padding: 20px;
+        }
+
+        .value {
+          padding: 15px;
+          font-size: 25px;
+          font-weight: bold;
+        }
+
+        .desc {
+          padding: 0px 15px 20px 15px;
+        }
+      `
+    ]
+  }
+
+  firstUpdated() {
+    this.formatting();
+  }
+
+  formatting() {
+    this.used_time = format(new Date(this.used_time), 'HH시간 mm분');
+    this.cpu_used_time = format(new Date(this.cpu_used_time), 'HH시간 mm분');
+    this.gpu_used_time = format(new Date(this.gpu_used_time), 'HH시간 mm분');
+  }
+
+  render() {
+    // language=HTML
+    return html`
+      <wl-card>
+        <wl-title level="3">이번달 통계</wl-title>
+        <div class="horizontal layout">
+          <div class="vertical center layout">
+            <span class="value">${this.num_sessions}</span>
+            <span class="desc">실행 세션 수</span>
+          </div>
+          <div class="vertical center layout">
+            <span class="value">${this.used_time}</span>
+            <span class="desc">사용 시간</span>
+          </div>
+          <div class="vertical center layout">
+            <span class="value">${this.cpu_used_time}</span>
+            <span class="desc">CPU 사용량</span>
+          </div>
+          <div class="vertical center layout">
+            <span class="value">${this.gpu_used_time}</span>
+            <span class="desc">GPU 사용량</span>
+          </div>
+          <div class="vertical center layout">
+            <span class="value">${this.disk_used}</span>
+            <span class="desc">디스크 사용량</span>
+          </div>
+          <div class="vertical center layout">
+            <span class="value">${this.traffic_used}</span>
+            <span class="desc">트래픽 사용량</span>
+          </div>
+        </div>
+      </wl-card>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "backend-ai-monthly-usage-panel": BackendAIMonthlyUsagePanel;
+  }
+}

--- a/src/components/backend-ai-usage-list.ts
+++ b/src/components/backend-ai-usage-list.ts
@@ -13,6 +13,7 @@ import 'weightless/tab';
 import 'weightless/select';
 import {BackendAiStyles} from './backend-ai-general-styles';
 import './backend-ai-chart';
+import "./backend-ai-monthly-usage-panel";
 
 import {
   IronFlex,
@@ -236,6 +237,7 @@ export default class BackendAIUsageList extends BackendAIPage {
     // language=HTML
     return html`
       <wl-card elevation="0">
+          <backend-ai-monthly-usage-panel></backend-ai-monthly-usage-panel>
         <h3 class="horizontal center layout">
           <wl-select label="${_t("statistics.SelectPeriod")}" style="width: 130px;" @input=${this.pulldownChange}>
             <option value disabled>${_t("statistics.SelectPeriod")}</option>

--- a/src/plastics/chart-js.ts
+++ b/src/plastics/chart-js.ts
@@ -67,7 +67,7 @@ export default class ChartJs extends LitElement {
   public render(): void | TemplateResult {
     return html`
       <div class="chart-top-container">
-        <div class="chart-shell chart-sub-container">
+        <div class="chart-sub-container">
           <canvas></canvas>
         </div>
       </div>


### PR DESCRIPTION
**add monthly usage panel on statistics page (text version)**
- create a new file named "backend-ai-monthly-usage-panel".
- deliver properties from "backend-ai-usage-list" to "backend-ai-monthly-usage-panel".