### PR TITLE
fix: add sessionUuid to work dialog when fetching first logs

### DIFF
--- a/src/components/backend-ai-session-list.ts
+++ b/src/components/backend-ai-session-list.ts
@@ -767,6 +767,7 @@ export default class BackendAiSessionList extends BackendAIPage {
       setTimeout(() => {
         this.shadowRoot.querySelector('#work-title').innerHTML = `${sessionName} (${sessionUuid})`;
         this.shadowRoot.querySelector('#work-area').innerHTML = `<pre>${logs}</pre>` || _text('session.NoLogs');
+        this.shadowRoot.querySelector('#work-dialog').sessionUuid = sessionUuid;
         this.shadowRoot.querySelector('#work-dialog').sessionName = sessionName;
         this.shadowRoot.querySelector('#work-dialog').accessKey = accessKey;
         this.shadowRoot.querySelector('#work-dialog').show();


### PR DESCRIPTION
This PR resolves #640.

Related: OP#675.