### PR TITLE
fix: Multiple clicks cause duplicated directory path

### DIFF
--- a/src/components/backend-ai-storage-list.ts
+++ b/src/components/backend-ai-storage-list.ts
@@ -1225,7 +1225,7 @@ export default class BackendAiStorageList extends BackendAIPage {
                  id = this.explorer.id,
                  dialog = false) {
     let job = globalThis.backendaiclient.vfolder.list_files(path, id);
-    job.then(value => {
+    return job.then(value => {
       this.shadowRoot.querySelector('#fileList-grid').selectedItems = [];
       this.explorer.files = JSON.parse(value.files);
       this.explorerFiles = this.explorer.files;
@@ -1256,21 +1256,18 @@ export default class BackendAiStorageList extends BackendAIPage {
    *
    * @param {Event} e - click the folder_open icon button
    * */
-  async _enqueueFolder(e) {
+  _enqueueFolder(e) {
     const button = e.target;
-    const minDelay = 300;
     
     // disable button to avoid executing extra onclick event
     button.setAttribute('disabled', 'true');
     const fn = e.target.getAttribute('name');
     this.explorer.breadcrumb.push(fn);
-    this._clearExplorer();
 
-    // set minimum delay to enable the button
-    await setTimeout(() => {
+    // enable button only if the operation is done.
+    this._clearExplorer().then(res => {
       button.removeAttribute('disabled');
-    }, minDelay);
-
+    });
   }
 
   _gotoFolder(e) {

--- a/src/components/backend-ai-storage-list.ts
+++ b/src/components/backend-ai-storage-list.ts
@@ -926,9 +926,9 @@ export default class BackendAiStorageList extends BackendAIPage {
       html`
         ${this._isDir(rowData.item) ?
         html`
-          <div class="indicator horizontal center layout" @click="${(e) => this._enqueueFolder(e)}" name="${rowData.item.filename}">
-            <mwc-icon-button class="fg controls-running" icon="folder_open"
-                               name="${rowData.item.filename}"></mwc-icon-button>
+          <div class="indicator horizontal center layout" name="${rowData.item.filename}">
+            <mwc-icon-button class="fg controls-running" icon="folder_open" name="${rowData.item.filename}"
+                               @click="${(e) => this._enqueueFolder(e)}"></mwc-icon-button>
             ${rowData.item.filename}
           </div>
        ` : html`
@@ -1256,10 +1256,21 @@ export default class BackendAiStorageList extends BackendAIPage {
    *
    * @param {Event} e - click the folder_open icon button
    * */
-  _enqueueFolder(e) {
+  async _enqueueFolder(e) {
+    const button = e.target;
+    const minDelay = 300;
+    
+    // disable button to avoid executing extra onclick event
+    button.setAttribute('disabled', 'true');
     const fn = e.target.getAttribute('name');
     this.explorer.breadcrumb.push(fn);
     this._clearExplorer();
+
+    // set minimum delay to enable the button
+    await setTimeout(() => {
+      button.removeAttribute('disabled');
+    }, minDelay);
+
   }
 
   _gotoFolder(e) {


### PR DESCRIPTION
I tried to find out the best way to ignore when the user clicks rapidly in the directory access icon(button) except using setTimeout, since setTimeout triggers unexpected results sometimes, and gives extra loads. Unfortunately, I couldn't get a decent solution to this. At least the main purpose of this PR is to avoid accessing non-existing sub-directory from the current directory path, and about that purpose, this PR works OK.

Still, there are some minor issues left.
Some click events are ignored when the user clicks the button, not often but it occurs.
If there is any idea to just fit in this issue, I would gladly replace from current commits.