### PR TITLE
fix: checkbox feature downsize in image downloading

### DIFF
--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -403,14 +403,19 @@
     "Base": "Base",
     "Constraint": "Constraint",
     "ResourceLimit": "Resource Limit",
-    "DescDownloadImage": "You are about to install the image: ",
+    "DescDeleteImage": "You are about to delete the image(s): ",
+    "DescDownloadImage": "You are about to install the image(s): ",
     "DescSignificantDownloadTime": "This process requires significant download time.",
+    "Install":"Install",
+    "Delete":"Delete",
     "Installed": "installed",
     "Installing": "installing",
     "Status": "Status",
     "Images": "Images",
     "ResourcePresets": "Resource Presets",
-    "Registries": "Registries"
+    "Registries": "Registries",
+    "SelectedImagesAlreadyInstalled": "Selected Image(s) are already installed or None. Please check again.",
+    "SelectedImagesNotInstalled": "Selected Images(s) are not installed. Please check again."
   },
   "resourcePreset": {
     "ResourcePresets": "Resource Presets",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -405,6 +405,9 @@
     "ResourceLimit": "Resource Limit",
     "DescDownloadImage": "You are about to install the image: ",
     "DescSignificantDownloadTime": "This process requires significant download time.",
+    "Installed": "installed",
+    "Installing": "installing",
+    "Status": "Status",
     "Images": "Images",
     "ResourcePresets": "Resource Presets",
     "Registries": "Registries"

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -400,14 +400,19 @@
     "Base": "기반",
     "Constraint": "제약",
     "ResourceLimit": "자원 제한",
-    "DescDownloadImage": "이미지를 다운로드하려고 합니다: ",
+    "DescDeleteImage": "다음 설치된 이미지를 삭제하려고 합니다: ",
+    "DescDownloadImage": "다음 이미지를 다운로드하려고 합니다: ",
     "DescSignificantDownloadTime": "다운로드에 매우 오랜 시간이 걸릴 것입니다.",
+    "Install": "설치",
+    "Delete": "삭제",
     "Installed": "설치 완료",
     "Installing": "설치 중",
     "Status": "상태",
     "Images": "이미지",
     "ResourcePresets": "자원 프리셋",
-    "Registries": "레지스트리"
+    "Registries": "레지스트리",
+    "SelectedImagesAlreadyInstalled": "선택된 이미지가 없거나 이미 설치 완료되었습니다. 다시 한 번 확인해주시기 바랍니다.",
+    "SelectedImagesNotInstalled": "선택된 이미지가 없거나 설치되지 않아 삭제할 수 없습니다. 다시 한 번 확인해주시기 바랍니다."
   },
   "resourcePreset": {
     "ResourcePresets": "자원 프리셋",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -402,6 +402,9 @@
     "ResourceLimit": "자원 제한",
     "DescDownloadImage": "이미지를 다운로드하려고 합니다: ",
     "DescSignificantDownloadTime": "다운로드에 매우 오랜 시간이 걸릴 것입니다.",
+    "Installed": "설치 완료",
+    "Installing": "설치 중",
+    "Status": "상태",
     "Images": "이미지",
     "ResourcePresets": "자원 프리셋",
     "Registries": "레지스트리"

--- a/src/components/backend-ai-environment-list.ts
+++ b/src/components/backend-ai-environment-list.ts
@@ -634,7 +634,7 @@ export default class BackendAIEnvironmentList extends BackendAIPage {
           <wl-icon>get_app</wl-icon>
           ${_t('environment.Install')}
         </wl-button>
-        <wl-button outlined class="operation" id="delete-image" @click="${this.openDeleteImageDialog}">
+        <wl-button outlined class="operation" id="delete-image" @click="${this.openDeleteImageDialog}" disabled>
           <wl-icon>delete</wl-icon>
           ${_t('environment.Delete')}
         </wl-button>

--- a/src/components/backend-ai-environment-list.ts
+++ b/src/components/backend-ai-environment-list.ts
@@ -29,6 +29,7 @@ import 'weightless/textfield';
 import 'weightless/label';
 
 import {default as PainKiller} from "./backend-ai-painkiller";
+// import { el } from "date-fns/locale";
 
 /**
  Backend.AI Environment List
@@ -43,11 +44,10 @@ export default class BackendAIEnvironmentList extends BackendAIPage {
   @property({type: Array}) allowed_registries = Array();
   @property({type: Object}) _boundRequirementsRenderer = this.requirementsRenderer.bind(this);
   @property({type: Object}) _boundControlsRenderer = this.controlsRenderer.bind(this);
-  @property({type: Object}) _boundCheckboxRenderer = this.checkboxRenderer.bind(this);
   @property({type: Object}) _boundInstallRenderer = this.installRenderer.bind(this);
   @property({type: Array}) servicePorts = Array();
   @property({type: Number}) selectedIndex = 0;
-  @property({type: Object}) selectedIndices = Object();
+  @property({type: Array}) selectedImages = Array();
   @property({type: Boolean}) _cuda_gpu_disabled = false;
   @property({type: Boolean}) _cuda_fgpu_disabled = false;
   @property({type: Boolean}) _rocm_gpu_disabled = false;
@@ -56,7 +56,9 @@ export default class BackendAIEnvironmentList extends BackendAIPage {
   @property({type: Object}) spinner = Object();
   @property({type: Object}) indicator = Object();
   @property({type: Object}) installImageDialog = Object();
-  @property({type: String}) installImageName = '';
+  @property({type: Object}) deleteImageDialog = Object();
+  @property({type: Array}) installImageNameList = Array();
+  @property({type: Array}) deleteImageNameList = Array();
   @property({type: Object}) installImageResource = Object();
   @property({type: Object}) selectedCheckbox = Object();
   @property({type: Object}) _grid = Object();
@@ -75,7 +77,6 @@ export default class BackendAIEnvironmentList extends BackendAIPage {
       // language=CSS
       css`
         vaadin-grid {
-          border: 0;
           font-size: 14px;
           height: calc(100vh - 150px);
         }
@@ -277,79 +278,120 @@ export default class BackendAIEnvironmentList extends BackendAIPage {
       })
   }
 
-  // /**
-  //  * Open the selected image.
-  //  *
-  //  * @param {object} index - Selected image's digest.
-  //  */
-  // openInstallImageDialog(digest) {
-  //   this.selectedIndices = this._grid.selectedItems;
-  //   console.log(this._grid);
-  //   console.dir(this._grid);
-  //   console.log(this.selectedIndices);
-  //   this.selectedIndex = this.images.findIndex(image => image.digest === digest);
-  //   let chosenImage = this.images[this.selectedIndex];
-  //   this.installImageName = chosenImage['registry'] + '/' + chosenImage['name'] + ':' + chosenImage['tag'];
-  //   this.installImageResource = {};
-  //   chosenImage['resource_limits'].forEach(elm => {
-  //     this.installImageResource[elm['key'].replace("_", ".")] = elm.min;
-  //   });
-  //   this.installImageDialog.show();
-  // }
-
+  /**
+   * Open the selected image.
+   * 
+   */
   openInstallImageDialog() {
-    this.selectedIndices = this._grid.selectedItems;
-    
+    // select only uninstalled images
+    this.selectedImages = this._grid.selectedItems.filter(images => {return !images.installed});
+    this.installImageNameList = this.selectedImages.map( image => {
+      return image['registry'] + '/' + image['name'] + ':' + image['tag'];
+    })
+
+    // show dialog only if selected image exists and uninstalled
+    if (this.selectedImages.length > 0) {
+      this.installImageDialog.show();
+    } else {
+      this.notification.text = _text('environment.SelectedImagesAlreadyInstalled');
+      this.notification.show();
+    }
   }
 
-  async _installImage() {
+  _installImage() {
     this.installImageDialog.hide();
-    if ('cuda.device' in this.installImageResource && 'cuda.shares' in this.installImageResource) {
-      this.installImageResource['gpu'] = 0;
-      this.installImageResource['fgpu'] = this.installImageResource['cuda.shares'];
-    } else if ('cuda.device' in this.installImageResource) {
-      this.installImageResource['gpu'] = this.installImageResource['cuda.device'];
-    }
-    // Add 256m to run the image.
-    if (this.installImageResource['mem'].endsWith('g')) {
-      this.installImageResource['mem'] = this.installImageResource['mem'].replace('g', '.5g');
-    } else if (this.installImageResource['mem'].endsWith('m')) {
-      this.installImageResource['mem'] = Number(this.installImageResource['mem'].slice(0, -1)) + 256 + 'm';
-    }
-    this.installImageResource['domain'] = globalThis.backendaiclient._config.domainName;
-    this.installImageResource['group_name'] = globalThis.backendaiclient.current_group;
+    this.selectedImages.forEach( async image => {
+      // make image installing status visible
+      let selectedImageLabel = '#' + image.registry.replace(/\./gi, '-') + '-' + image.name.replace('/', '-') + '-' + image.tag.replace(/\./gi, '-');
+      this._grid.querySelector(selectedImageLabel).setAttribute('style', 'display:block;');
 
-    this.notification.text = "Installing " + this.installImageName + ". It takes time so have a cup of coffee!";
-    this.notification.show();
-    let indicator = await this.indicator.start('indeterminate');
-    indicator.set(10, 'Downloading...');
-    globalThis.backendaiclient.get_resource_slots().then((response) => {
-      let results = response;
-      if ('cuda.device' in results && 'cuda.shares' in results) { // Can be possible after 20.03
-        if ('fgpu' in this.installImageResource && 'gpu' in this.installImageResource) { // Keep fgpu only.
-          delete this.installImageResource['gpu'];
-          delete this.installImageResource['cuda.device'];
-        }
-      } else if ('cuda.device' in results) { // GPU mode
-        delete this.installImageResource['fgpu'];
-        delete this.installImageResource['cuda.shares'];
-      } else if ('cuda.shares' in results) { // Fractional GPU mode
-        delete this.installImageResource['gpu'];
-        delete this.installImageResource['cuda.device'];
+      let imageName = image['registry'] + '/' + image['name'] + ':' + image['tag'];
+      let imageResource = Object();
+      image['resource_limits'].forEach( el => {
+        imageResource[ el['key'].replace("_", ".")] = el.min;
+      });
+
+      if ('cuda.device' in imageResource && 'cuda.shares' in imageResource) {
+        imageResource['gpu'] = 0;
+        imageResource['fgpu'] = imageResource['cuda.shares'];
+      } else if ('cuda.device' in imageResource) {
+        imageResource['gpu'] = imageResource['cuda.device'];
       }
-      return globalThis.backendaiclient.image.install(this.installImageName, this.installImageResource);
-    }).then((response) => {
-      indicator.set(100, 'Install finished.');
-      indicator.end(1000);
-      this._getImages();
-    }).catch(err => {
-      this._uncheckSelectedRow();
-      this.notification.text = PainKiller.relieve(err.title);
-      this.notification.detail = err.message;
-      this.notification.show(true, err);
-      indicator.set(100, _t('environment.DescProblemOccurred'));
-      indicator.end(1000);
+      
+      // Add 256m to run the image.
+      if (imageResource['mem'].endsWith('g')) {
+        imageResource['mem'] = imageResource['mem'].replace('g', '.5g');
+      } else if (imageResource['mem'].endsWith('m')) {
+        imageResource['mem'] = Number(imageResource['mem'].slice(0, -1)) + 256 + 'm';
+      }
+
+      imageResource['domain'] = globalThis.backendaiclient._config.domainName;
+      imageResource['group_name'] = globalThis.backendaiclient.current_group;
+
+      this.notification.text = "Installing " + imageName + ". It takes time so have a cup of coffee!";
+      this.notification.show();
+      let indicator = await this.indicator.start('indeterminate');
+      indicator.set(10, 'Downloading...');
+      globalThis.backendaiclient.get_resource_slots().then((response) => {
+        let results = response;
+        if ('cuda.device' in results && 'cuda.shares' in results) { // Can be possible after 20.03
+          if ('fgpu' in imageResource && 'gpu' in imageResource) { // Keep fgpu only.
+            delete imageResource['gpu'];
+            delete imageResource['cuda.device'];
+          }
+        } else if ('cuda.device' in results) { // GPU mode
+          delete imageResource['fgpu'];
+          delete imageResource['cuda.shares'];
+        } else if ('cuda.shares' in results) { // Fractional GPU mode
+          delete imageResource['gpu'];
+          delete imageResource['cuda.device'];
+        }
+        return globalThis.backendaiclient.image.install(imageName, imageResource);
+      }).then((response) => {
+        indicator.set(100, 'Install finished.');
+        indicator.end(1000);
+
+        // change installing -> installed
+        this._grid.querySelector(selectedImageLabel).className = 'installed';
+        this._grid.querySelector(selectedImageLabel).innerHTML = _text('environment.Installed');
+
+      }).catch(err => {
+        // if something goes wrong during installation
+        this._grid.querySelector(selectedImageLabel).className = _text('environment.Installing');
+        this._grid.querySelector(selectedImageLabel).setAttribute('style', 'display:none;');
+
+        this._uncheckSelectedRow();
+        this.notification.text = PainKiller.relieve(err.title);
+        this.notification.detail = err.message;
+        this.notification.show(true, err);
+        indicator.set(100, _t('environment.DescProblemOccurred'));
+        indicator.end(1000);
+      });
     });
+  }
+  
+  /**
+   * Open images to delete.
+   * 
+   */
+  openDeleteImageDialog() {
+    // select only installed images
+    this.selectedImages = this._grid.selectedItems.filter(images => {return images.installed});
+    this.deleteImageNameList = this.selectedImages.map( image => {
+      return image['registry'] + '/' + image['name'] + ':' + image['tag'];
+    });
+    // show dialog only if selected image exists and installed
+    if (this.selectedImages.length > 0) {
+      this.deleteImageDialog.show();
+    } else {
+      this.notification.text = _text('environment.SelectedImagesNotInstalled');
+      this.notification.show();
+    }
+  }
+
+
+  _deleteImage() {
+    /** TO DO: API function call to delete selected images */
   }
 
   /**
@@ -519,58 +561,34 @@ export default class BackendAIEnvironmentList extends BackendAIPage {
   controlsRenderer(root, column, rowData) {
     render(
       html`
-        <div
-          id="controls"
-          class="layout horizontal flex center"
-        >
+        <div id="controls" class="layout horizontal flex center">
           <wl-button fab flat inverted
             class="fg blue controls-running"
             @click=${() => {
-        this.selectedIndex = rowData.index;
-        this._setPulldownDefaults(this.images[this.selectedIndex].resource_limits);
-        this._launchDialogById("#modify-image-dialog");
-        this.requestUpdate();
-      }}>
+              this.selectedIndex = rowData.index;
+              this._setPulldownDefaults(this.images[this.selectedIndex].resource_limits);
+              this._launchDialogById("#modify-image-dialog");
+              this.requestUpdate();
+           }}>
             <wl-icon>settings</wl-icon>
           </wl-button>
           <wl-button fab flat inverted
             class="fg pink controls-running"
             @click=${() => {
-        if (this.selectedIndex !== rowData.index) this._clearRows();
-        this.selectedIndex = rowData.index;
-        this._decodeServicePort();
-        this._launchDialogById("#modify-app-dialog");
-        this.requestUpdate();
-      }}>
+              if (this.selectedIndex !== rowData.index) {
+                this._clearRows();
+              }
+              this.selectedIndex = rowData.index;
+              this._decodeServicePort();
+              this._launchDialogById("#modify-app-dialog");
+              this.requestUpdate();
+          }}>
             <wl-icon>apps</wl-icon>
           </wl-button>
         </div>
       `,
       root
     )
-  }
-
-  /**
-   * Render an install dialog.
-   *
-   * @param {DOM element} root
-   * @param {<vaadin-grid-column> element} column
-   * @param {object} rowData
-   */
-  checkboxRenderer(root, column, rowData) {
-    render(
-      // language=HTML
-      html`
-        <div class="layout horizontal center center-justified" style="margin:0; padding:0;">
-          <wl-checkbox id="${rowData.item.name}" style="--checkbox-size:12px;"
-              @click="${(e) => {
-                if (e.target.checked) {
-                  this.selectedCheckbox =  e.target;
-                }
-              }}">
-          </wl-checkbox>
-        </div>
-      `, root);
   }
 
 /**
@@ -585,7 +603,23 @@ export default class BackendAIEnvironmentList extends BackendAIPage {
       // language=HTML
       html`
         <div class="layout horizontal center center-justified">
-          ${rowData.item.installed ? html`<wl-label class="installed">installed</wl-label>` : html``}
+          ${rowData.item.installed ? html`
+          <wl-label class="installed"
+              id="${rowData.item.registry.replace(/\./gi, '-') + '-' + 
+                    rowData.item.name.replace('/','-') + '-' + 
+                    rowData.item.tag.replace(/\./gi, '-')}">
+            ${_t('environment.Installed')}
+          </wl-label>
+          ` : 
+          html`
+          <wl-label class="installing"
+            id="${rowData.item.registry.replace(/\./gi, '-') + '-' + 
+                  rowData.item.name.replace('/','-') + '-' + 
+                  rowData.item.tag.replace(/\./gi, '-')}"
+            style="display:none">
+            ${_t('environment.Installing')}
+            </wl-label>
+          `}
         </div>
       `
     , root);
@@ -598,11 +632,11 @@ export default class BackendAIEnvironmentList extends BackendAIPage {
       <div class="horizontal layout flex end-justified" style="margin:10px;">
         <wl-button outlined class="operation" id="install-image" @click="${this.openInstallImageDialog}">
           <wl-icon>get_app</wl-icon>
-          Install
+          ${_t('environment.Install')}
         </wl-button>
-        <wl-button outlined class="operation" id="delete-image">
+        <wl-button outlined class="operation" id="delete-image" @click="${this.openDeleteImageDialog}">
           <wl-icon>delete</wl-icon>
-          Delete
+          ${_t('environment.Delete')}
         </wl-button>
       </div>
       <vaadin-grid theme="row-stripes column-borders compact" aria-label="Environments" id="testgrid" .items="${this.images}">
@@ -804,19 +838,45 @@ export default class BackendAIEnvironmentList extends BackendAIPage {
       <backend-ai-dialog id="install-image-dialog" fixed backdrop persistent>
         <span slot="title">Let's double-check</span>
         <div slot="content">
-          <p>${_t("environment.DescDownloadImage")} <span style="color:blue;">${this.installImageName}</span></p>
+          <p>${_t("environment.DescDownloadImage")}</p>
+          <p style="margin:auto; "><span style="color:blue;">
+          ${this.installImageNameList.map(el => {
+            return html`${el}<br />`
+          })}
+          </span></p>
           <p>${_t("environment.DescSignificantDownloadTime")} ${_t("dialog.ask.DoYouWantToProceed")}</p>
         </div>
         <div slot="footer" class="horizontal flex layout">
           <div class="flex"></div>
-          <wl-button class="cancel" inverted flat
-              @click="${(e) => {
-      this._hideDialog(e)
-      this._uncheckSelectedRow();
-    }}">
+          <wl-button class="cancel" inverted flat @click="${(e) => {
+                  this._hideDialog(e);
+                  this._uncheckSelectedRow();
+          }}">
             ${_t("button.Cancel")}
           </wl-button>
           <wl-button class="ok" @click="${() => this._installImage()}">${_t("button.Okay")}</wl-button>
+        </div>
+      </backend-ai-dialog>
+      <backend-ai-dialog id="delete-image-dialog" fixed backdrop persistent>
+        <span slot="title">Let's double-check</span>
+        <div slot="content">
+          <p>${_t("environment.DescDeleteImage")}</p>
+          <p style="margin:auto; "><span style="color:blue;">
+          ${this.deleteImageNameList.map(el => {
+            return html`${el}<br />`
+          })}
+          </span></p>
+          <p>${_t("dialog.ask.DoYouWantToProceed")}</p>
+        </div>
+        <div slot="footer" class="horizontal flex layout">
+          <div class="flex"></div>
+          <wl-button class="cancel" inverted flat @click="${(e) => {
+                  this._hideDialog(e);
+                  this._uncheckSelectedRow();
+          }}">
+            ${_t("button.Cancel")}
+          </wl-button>
+          <wl-button class="ok" @click="${() => this._deleteImage()}">${_t("button.Okay")}</wl-button>
         </div>
       </backend-ai-dialog>
     `;
@@ -898,7 +958,8 @@ export default class BackendAIEnvironmentList extends BackendAIPage {
    * Deselect the selected row from the environment list.
    */
   _uncheckSelectedRow() {
-    this.selectedCheckbox.checked = false;
+    // empty out selectedItem
+    this._grid.selectedItems = [];
   }
 
   firstUpdated() {
@@ -906,6 +967,7 @@ export default class BackendAIEnvironmentList extends BackendAIPage {
     this.indicator = globalThis.lablupIndicator;
     this.notification = globalThis.lablupNotification;
     this.installImageDialog = this.shadowRoot.querySelector('#install-image-dialog');
+    this.deleteImageDialog = this.shadowRoot.querySelector('#delete-image-dialog');
 
     if (typeof globalThis.backendaiclient === 'undefined' || globalThis.backendaiclient === null || globalThis.backendaiclient.ready === false) {
       document.addEventListener('backend-ai-connected', () => {
@@ -917,8 +979,16 @@ export default class BackendAIEnvironmentList extends BackendAIPage {
     }
     this._grid = this.shadowRoot.querySelector('#testgrid');
     this._grid.addEventListener('sorter-changed', (e) => {
-      this._refreshSorter(e)
+      this._refreshSorter(e);
     });
+
+    // uncheck every checked rows when dialog is closed
+    this.shadowRoot.querySelector('#install-image-dialog').addEventListener("didHide", () => {
+      this._uncheckSelectedRow();
+    });
+    this.shadowRoot.querySelector('#delete-image-dialog').addEventListener('didHide', () => {
+      this._uncheckSelectedRow();
+    })
   }
 
   /**


### PR DESCRIPTION
After merging this PR, there are several things will be changed in Images tab of 'Environments & Presets' page.
※ NOTICE: This feature is available in admin or super-admin account only.
You can see the detail below. (unchecked features are WIP.)

- [x] One or more selected image can be downloaded by clicking checkbox and clicking install button at right top.
- [ ] One or more selected image can be deleted by clicking checkbox and clicking delete button at right top.
- [x] If the user accidentally tries to install that is already checked, it will be filtered automatically, and at deleting part as vice versa.
- [x] The user can see image status by Installing / Installed tag next to the checkbox column.
- [x] All of the selected checkboxes will be deselected after the installation and deletion whether it fails or not.