### PR TITLE
fix: backend.AI logo routes to the summary page

### DIFF
--- a/src/components/backend-ai-console.ts
+++ b/src/components/backend-ai-console.ts
@@ -939,11 +939,8 @@ export default class BackendAIConsole extends connect(store)(LitElement) {
       <mwc-drawer id="app-body" class="${this.mini_ui ? "mini-ui" : ""}" style="position:fixed;visibility:hidden;">
         <div class="drawer-content drawer-menu" style="height:100vh;position:fixed;">
           <div id="portrait-bar" class="draggable">
-            <div class="horizontal center layout flex bar draggable" style="cursor:pointer;">
-              <div class="portrait-canvas">
-                <img style="width:43px; height:43px; display:none;" src="manifest/backend.ai-brand-white.svg"
-                  sizing="contain" />
-              </div>
+            <div class="horizontal center layout flex bar draggable" style="cursor:pointer;" @click="${() => this._moveTo('/summary')}">
+              <div class="portrait-canvas"></div>
               <div class="vertical start-justified layout full-menu" style="margin-left:10px;margin-right:10px;">
                 <div class="site-name"><span class="bold">Backend</span>.AI</div>
                 ${this.siteDescription ?


### PR DESCRIPTION
This PR resolves #738.