### PR TITLE
fix: show inner tab of users page properly

### DIFF
--- a/src/components/backend-ai-credential-view.ts
+++ b/src/components/backend-ai-credential-view.ts
@@ -651,6 +651,18 @@ export default class BackendAICredentialView extends BackendAIPage {
     }
     this._activeTab = tab.title;
     this.shadowRoot.querySelector('#' + tab.title).style.display = 'block';
+    // show inner tab(active) after selecting outer tab
+    switch(this._activeTab) {
+      case "user-lists":
+      case "credential-lists":
+        let tabKeyword = this._activeTab.substring(0, this._activeTab.length - 1); // to remove '-s'.
+        let innerTab = this.shadowRoot.querySelector('wl-tab[value=active-' + tabKeyword + ']');
+        innerTab.checked = true;
+        this._showList(innerTab);
+        break;
+      default:
+        break;
+    }
   }
 
   /**


### PR DESCRIPTION
> NOTICE: only admin or super-admin have an access to 'Users' page.

This is the hotfix for force activating inner-tabs(active and inactive) of 'Users' page.
After this PR, when the user clicks the tab with inner-tab in the 'Users' page will automatically activates inner 'active' tab of each tab.