### PR TITLE
fix: remove logic where is_amdin is not defined

### DIFF
--- a/src/backend-ai-app.ts
+++ b/src/backend-ai-app.ts
@@ -37,9 +37,8 @@ export const navigate = (path: any, params: Object = {}) => (dispatch: any) => {
   // you can do here
   if (['agent', 'resource', 'user', 'credential', 'environment', 'settings',
   'maintenance', 'information'].includes(page)) {
-    console.log(globalThis.backendaiclient);
-      // page = 'summary';
-      // globalThis.history.pushState({}, '', '/summary');
+    // page = 'summary';
+    // globalThis.history.pushState({}, '', '/summary');
   }
   dispatch(loadPage(page, params));
 

--- a/src/components/backend-ai-console.ts
+++ b/src/components/backend-ai-console.ts
@@ -364,12 +364,6 @@ export default class BackendAIConsole extends connect(store)(LitElement) {
         globalThis.history.pushState({}, '', '/unauthorized');
         store.dispatch(navigate(decodeURIComponent(this._page)));
       }
-    } else {
-      if (this._page === 'unauthorized') {
-        this._page = 'summary';
-        globalThis.history.pushState({}, '', '/summary');
-        store.dispatch(navigate(decodeURIComponent(this._page)));
-      }
     }
   }
 
@@ -781,11 +775,6 @@ export default class BackendAIConsole extends connect(store)(LitElement) {
         let modified_view: (string | undefined) = view.split(/[\/]+/).pop();
         if (typeof modified_view != 'undefined') {
           view = modified_view;
-        }
-      }
-      if (this.adminOnlyPages.includes(view)) {
-        if (!this.is_admin || !this.is_superadmin) {
-          view = 'unauthorized';
         }
       }
       this._page = view;


### PR DESCRIPTION
Refreshing from admin pages always result in redirection to the summary page, even for admins.