### PR TITLE
fix: automatic logout when API keypair is not accessible

### DIFF
--- a/src/components/backend-ai-login.ts
+++ b/src/components/backend-ai-login.ts
@@ -969,6 +969,8 @@ export default class BackendAILogin extends BackendAIPage {
         this.notification.text = PainKiller.relieve('Login failed. Check login information.');
         this.notification.show(true);
       }
+      this._enableUserInput();
+      this.client.logout();
     });
   }
 

--- a/src/components/backend-ai-login.ts
+++ b/src/components/backend-ai-login.ts
@@ -969,8 +969,13 @@ export default class BackendAILogin extends BackendAIPage {
         this.notification.text = PainKiller.relieve('Login failed. Check login information.');
         this.notification.show(true);
       }
+      if (err.statusCode === 401) {
+        // When authorization failed, it is highly likely that session cookie
+        // is used which tried to use non-existent API keypairs
+        console.log('automatic logout ...');
+        this.client.logout();
+      }
       this._enableUserInput();
-      this.client.logout();
     });
   }
 

--- a/src/components/backend-ai-painkiller.ts
+++ b/src/components/backend-ai-painkiller.ts
@@ -25,8 +25,7 @@ export default class BackendAIPainKiller {
     "TypeError: NetworkError when attempting to fetch resource.": "error.NetworkConnectionFailed",
     // Login
     "Login failed. Check login information.": "error.LoginFailed",
-    "server responded failure: 401 Unauthorized - Credential/signature mismatch. (Access key not found)": "error.LoginInformationMismatch",
-    "server responded failure: 401 Unauthorized - Credential/signature mismatch.": "error.LoginInformationMismatch",
+    "User credential mismatch.": "error.LoginFailed",
     "Authentication failed. Check information and manager status.": "error.AuthenticationFailed",
     "Too many failed login attempts": "error.TooManyLoginFailures",
     // virtual folders
@@ -40,6 +39,8 @@ export default class BackendAIPainKiller {
     "Cannot read property 'split' of undefined": "error.UserHasNoGroup",
   };
   static regexTable = {
+    '\\w*Access key not found\\w*': "error.LoginInformationMismatch",
+    '\\w*401 Unauthorized - Credential/signature mismatch\\w*': "error.LoginInformationMismatch",
     'integrity error: duplicate key value violates unique constraint "pk_resource_presets"[\\n]DETAIL:  Key \\(name\\)=\\([\\w]+\\) already exists.[\\n]': 'error.ResourcePolicyAlreadyExist',
     'integrity error: duplicate key value violates unique constraint "pk_scaling_groups"[\\n]DETAIL:  Key \\(name\\)=\\([\\w]+\\) already exists.[\\n]': 'error.ScalingGroupAlreadyExist',
     'integrity error: duplicate key value violates unique constraint "uq_users_username"[\\n]DETAIL:  Key \\(username\\)=\\([\\w]+\\) already exists.[\\n]': 'error.UserNameAlreadyExist',


### PR DESCRIPTION
This PR resolves https://github.com/lablup/backend.ai-console/issues/860.

When API keypair is not accessible in `_connectViaGQL`, just automatically logout to invalidate existing session information.