### PR TITLE
fix: notification error in safari and limit max-width of sidebar

### DIFF
--- a/src/components/backend-ai-console-styles.ts
+++ b/src/components/backend-ai-console-styles.ts
@@ -431,6 +431,7 @@ export const BackendAiConsoleStyles = [
     .portrait-canvas {
       margin-left: 18px;
       border-radius: 8px;
+      min-width: 48px; /* only apply this style feature if it's Backend.AI logo */
       width: 48px;
       height: 48px;
       background-color: #ffffff;

--- a/src/components/backend-ai-console-styles.ts
+++ b/src/components/backend-ai-console-styles.ts
@@ -77,6 +77,7 @@ export const BackendAiConsoleStyles = [
       background-color: transparent;
       color: var(--general-sidebar-topbar-color);
       height: 80px;
+      max-width: 250px; /* prevent sidebar from expanding over its width limit */
     }
 
     .drawer-menu h3 {

--- a/src/components/backend-ai-console.ts
+++ b/src/components/backend-ai-console.ts
@@ -1229,7 +1229,7 @@ export default class BackendAIConsole extends connect(store)(LitElement) {
               <div class="vertical start-justified layout full-menu" style="margin-left:10px;margin-right:10px;">
                 <div class="site-name"><span class="bold">Backend</span>.AI</div>
                 ${this.siteDescription ? html`
-                  <div class="site-name" style="font-size:13px;text-align:right;">
+                  <div class="site-name" style="font-size:13px;text-align:left;">
                     ${this.siteDescription}
                   </div>` : html``}
               </div>

--- a/src/components/backend-ai-credential-view.ts
+++ b/src/components/backend-ai-credential-view.ts
@@ -214,6 +214,12 @@ export default class BackendAICredentialView extends BackendAIPage {
           --mdc-menu-item-height : auto;
         }
 
+        mwc-menu#dropdown-menu {
+          position: relative;
+          left: -10px;
+          top: 50px;
+        }
+
         mwc-list-item {
           font-size : 14px;
         }

--- a/src/components/backend-ai-session-view.ts
+++ b/src/components/backend-ai-session-view.ts
@@ -121,6 +121,12 @@ export default class BackendAiSessionView extends BackendAIPage {
           --mdc-menu-item-height : auto;
         }
 
+        mwc-menu#dropdown-menu {
+          position: relative;
+          left: -170px;
+          top: 50px;
+        }
+        
         mwc-list-item {
           font-size : 14px;
         }

--- a/src/components/lablup-notification.ts
+++ b/src/components/lablup-notification.ts
@@ -92,16 +92,24 @@ export default class LablupNotification extends LitElement {
   firstUpdated() {
     if ("Notification" in window) {
       //console.log(Notification.permission);
-      if (Notification.permission === "granted") {
-        this.supportDesktopNotification = true;
-      } else if (Notification.permission !== "denied") {
-        Notification.requestPermission().then(() => {
-          this.supportDesktopNotification = true;
-        });
+
+      /**
+       * check whether userAgent is safari or not.
+       * NOTE: safari browser only allows callback function instead of Promise
+       */
+      let is_safari = navigator.userAgent.indexOf("Safari") > -1;
+      if (is_safari) {
+        if (["default", "granted", "denied"].includes(Notification.permission)) {
+          Notification.requestPermission(() => {
+            this.supportDesktopNotification = true;
+          });
+        }
       } else {
-        Notification.requestPermission().then(() => {
-          this.supportDesktopNotification = true;
-        });
+        if (["default", "granted", "denied"].includes(Notification.permission)) {
+          Notification.requestPermission().then(() => {
+            this.supportDesktopNotification = true;
+          });
+        }
       }
     }
     this._readUserSetting('desktop_notification', true);

--- a/src/components/lablup-notification.ts
+++ b/src/components/lablup-notification.ts
@@ -93,24 +93,12 @@ export default class LablupNotification extends LitElement {
     if ("Notification" in window) {
       //console.log(Notification.permission);
 
-      /**
-       * check whether userAgent is safari or not.
-       * NOTE: safari browser only allows callback function instead of Promise
-       */
-      let is_safari = navigator.userAgent.indexOf("Safari") > -1;
-      if (is_safari) {
-        if (["default", "granted", "denied"].includes(Notification.permission)) {
-          Notification.requestPermission(() => {
-            this.supportDesktopNotification = true;
-          });
+      // works on all browsers without promise error including Safari
+      Promise.resolve(Notification.requestPermission()).then((permission) => {
+        if (["default", "granted", "denied"].includes(permission)) {
+          this.supportDesktopNotification = true;
         }
-      } else {
-        if (["default", "granted", "denied"].includes(Notification.permission)) {
-          Notification.requestPermission().then(() => {
-            this.supportDesktopNotification = true;
-          });
-        }
-      }
+      });
     }
     this._readUserSetting('desktop_notification', true);
     if (this.options['desktop_notification'] === false) {


### PR DESCRIPTION
This PR contains two minor bug fix.
- notification error exposed in browser console in Safari (version: 14.0).
screenshot: 
![promise_error](https://user-images.githubusercontent.com/46954439/102579043-02c2d480-413f-11eb-9b99-c278c26370a6.png)

- limit max-width of sidebar and preserve logo ratio and size in the header of sidebar. (reported by @adrysn)