### PR TITLE
fix: monkeypatch for min, max value force adjustment in lablup-slider

### DIFF
--- a/src/components/lablup-slider.ts
+++ b/src/components/lablup-slider.ts
@@ -147,6 +147,10 @@ export default class LablupSlider extends LitElement {
       }
       return decimal_places.toString().split(".")[1].length || 0;
       })(this.step));
+    
+    //monkeypatch: force adjusting min value if min value exceeds max value
+    this.min = (this.min > this.max) ? this.max : this.min;
+    
     if (this.textfield.value > this.max) {
       this.textfield.value = this.max;
     }


### PR DESCRIPTION
After merging this PR, the value error will be handled, which triggered by the status that min value greater than max value
in lablup-slider component.