### PR TITLE
fix: rearrange layout

### DIFF
--- a/src/components/backend-ai-app-launcher.ts
+++ b/src/components/backend-ai-app-launcher.ts
@@ -691,7 +691,7 @@ export default class BackendAiAppLauncher extends BackendAIPage {
     let dialog = this.shadowRoot.querySelector('#terminal-guide');
     const lastChild = dialog.children[dialog.children.length - 1];
     const div: HTMLElement = document.createElement('div');
-    div.setAttribute('class', 'horizontal layout flex');
+    div.setAttribute('class', 'horizontal layout flex center');
 
     const checkbox = document.createElement('mwc-checkbox');
     checkbox.setAttribute("id", "hide-guide");

--- a/src/components/backend-ai-console-styles.ts
+++ b/src/components/backend-ai-console-styles.ts
@@ -156,16 +156,19 @@ export const BackendAiConsoleStyles = [
       display: none;
     }
 
-    .drawer-menu footer {
+    .drawer-menu footer,
+    footer#short-height {
       bottom: 0;
       color: var(--general-sidebar-footer-color, #aaaaaa);
       background-color: var(--general-sidebar-background-color);
       margin: 0;
       padding-bottom: 5px;
+      line-height: 1;
       font-size: 10px;
     }
 
-    .drawer-menu footer a {
+    .drawer-menu footer a,
+    footer#short-height a {
       color: var(--general-sidebar-footer-color, #aaaaaa) !important;
     }
 
@@ -270,7 +273,8 @@ export const BackendAiConsoleStyles = [
       -webkit-app-region: drag !important;
     }
 
-    .drawer-menu footer {
+    .drawer-menu footer,
+    footer#short-height {
       width: 250px;
     }
 
@@ -458,6 +462,10 @@ export const BackendAiConsoleStyles = [
       display: none !important;
     }
 
+    footer#short-height {
+      display: none;
+    }
+
     #portrait-bar {
       height: 64px;
       padding-top: 15px;
@@ -551,6 +559,16 @@ export const BackendAiConsoleStyles = [
       #sidebar-navbar-footer {
         background-color: var(--general-sidebar-background-color);
         color: var(--general-sidebar-color);
+      }
+    }
+
+    @media screen and (max-height: 953px) {
+      footer#short-height {
+        display: block;
+      }
+
+      footer {
+        display: none;
       }
     }
 

--- a/src/components/backend-ai-console-styles.ts
+++ b/src/components/backend-ai-console-styles.ts
@@ -70,6 +70,7 @@ export const BackendAiConsoleStyles = [
       -ms-overflow-style: none;
       will-change: transform;
       background-color: var(--general-sidebar-background-color, #fafafa);
+      scrollbar-width: none;
     }
 
     .drawer-menu .portrait-bar {
@@ -460,6 +461,9 @@ export const BackendAiConsoleStyles = [
 
     .drawer-menu::-webkit-scrollbar {
       display: none !important;
+      -webkit-appearance: none;
+      width: 0 !important;
+      height: 0;
     }
 
     footer#short-height {

--- a/src/components/backend-ai-console.ts
+++ b/src/components/backend-ai-console.ts
@@ -1330,6 +1330,29 @@ export default class BackendAIConsole extends connect(store)(LitElement) {
                 </mwc-list-item>
                 `) : html``}
             ` : html``}
+            <footer id="short-height">
+              <div class="terms-of-use full-menu" style="margin-bottom:10px;">
+                <small style="font-size:11px;">
+                  <a @click="${() => this.showTOSAgreement()}">${_t("console.menu.TermsOfService")}</a>
+                  ·
+                  <a style="color:forestgreen;" @click="${() => this.showPPAgreement()}">${_t("console.menu.PrivacyPolicy")}</a>
+                  ·
+                  <a @click="${() => this.splash.show()}">${_t("console.menu.AboutBackendAI")}</a>
+                  ${this.allow_signout === true ? html`
+                  ·
+                  <a @click="${() => this.loginPanel.signout()}">${_t("console.menu.LeaveService")}</a>
+                  ` : html``}
+                </small>
+              </div>
+              <address class="full-menu">
+                <small class="sidebar-footer">Lablup Inc.</small>
+                <small class="sidebar-footer" style="font-size:9px;">20.12.6.201230</small>
+              </address>
+              <div id="sidebar-navbar-footer" class="vertical start end-justified layout" style="margin-left:16px;">
+                <backend-ai-help-button active style="margin-left:4px;"></backend-ai-help-button>
+                <mwc-icon-button id="usersettings-menu-icon" icon="settings" slot="graphic" class="fg ${this._page === 'usersettings' ? 'yellow' : 'white'}" style="margin-left:4px;" @click="${() => this._moveTo('/usersettings')}"></mwc-icon-button>
+              </div>
+            </footer>
           </mwc-list>
           <footer>
             <div class="terms-of-use full-menu" style="margin-bottom:10px;">

--- a/src/components/backend-ai-console.ts
+++ b/src/components/backend-ai-console.ts
@@ -135,6 +135,7 @@ export default class BackendAIConsole extends connect(store)(LitElement) {
                                              "information", "github", "import", 'unauthorized'];
   @property({type: Array}) adminOnlyPages = ["experiment", "credential", "environment", "agent",
                                              "settings", "maintenance", "information"];
+  @property({type: Array}) superAdminOnlyPages = ["agent", "settings", "maintenance", "information"];
   @property({type: Number}) timeoutSec = 5;
 
   constructor() {
@@ -399,12 +400,20 @@ export default class BackendAIConsole extends connect(store)(LitElement) {
     });
     this.addTooltips();
     this.sidebarMenu.style.minHeight = (this.is_admin || this.is_superadmin) ? '600px' : '250px';
-    if (!this.is_admin || !this.is_superadmin) {
+    // redirect to unauthorized page when user's role is neither admin nor superadmin
+    if (!this.is_admin && !this.is_superadmin) {
       if (this.adminOnlyPages.includes(this._page) || this._page === 'unauthorized') {
         this._page = 'unauthorized';
         globalThis.history.pushState({}, '', '/unauthorized');
         store.dispatch(navigate(decodeURIComponent(this._page)));
       }
+    }
+
+    // redirect to unauthorize page when admin user tries to access superadmin only page
+    if (this.is_admin && this.superAdminOnlyPages.includes(this._page)) {
+      this._page = 'unauthorized';
+      globalThis.history.pushState({}, '', '/unauthorized');
+      store.dispatch(navigate(decodeURIComponent(this._page)));
     }
   }
 

--- a/src/components/backend-ai-console.ts
+++ b/src/components/backend-ai-console.ts
@@ -410,7 +410,7 @@ export default class BackendAIConsole extends connect(store)(LitElement) {
     }
 
     // redirect to unauthorize page when admin user tries to access superadmin only page
-    if (this.is_admin && this.superAdminOnlyPages.includes(this._page)) {
+    if (!this.is_superadmin && this.superAdminOnlyPages.includes(this._page)) {
       this._page = 'unauthorized';
       globalThis.history.pushState({}, '', '/unauthorized');
       store.dispatch(navigate(decodeURIComponent(this._page)));

--- a/src/components/backend-ai-credential-view.ts
+++ b/src/components/backend-ai-credential-view.ts
@@ -205,6 +205,10 @@ export default class BackendAICredentialView extends BackendAIPage {
           margin-bottom: 10px;
         }
 
+        mwc-textfield#id_user_name {
+          margin-bottom: 18px;
+        }
+
         #new-user-dialog wl-textfield {
           margin-bottom: 15px;
         }
@@ -256,7 +260,6 @@ export default class BackendAICredentialView extends BackendAIPage {
             width: 5px;
           }
         }
-
       `];
   }
 

--- a/src/components/backend-ai-credential-view.ts
+++ b/src/components/backend-ai-credential-view.ts
@@ -163,7 +163,7 @@ export default class BackendAICredentialView extends BackendAIPage {
         wl-label {
           width: 100%;
           min-width: 60px;
-          font-size: 11px;
+          font-size: 10px; // 11px;
           --label-font-family: Roboto, Noto, sans-serif;
         }
 

--- a/src/components/backend-ai-permission-denied-view.ts
+++ b/src/components/backend-ai-permission-denied-view.ts
@@ -57,6 +57,49 @@ export default class BackendAIPermissionDeniedView extends BackendAIPage {
         width: auto;
       }
 
+      img#unauthorized-access {
+        width: 400px;
+        margin: 20px;
+      }
+
+      div.page-layout {
+        display: flex;
+        -ms-flex-direction: row;
+        -webkit-flex-direction: row;
+        flex-direction: row;
+        align-items: center;
+        margin: 20px;
+      }
+
+      div.desc {
+        width: 100%;
+      }
+
+      @media screen and (max-width: 1015px) {
+        div.page-layout {
+          -ms-flex-direction: column;
+          -webkit-flex-direction: column;
+          flex-direction: column;
+          align-content: center;
+        }
+
+        div.desc {
+          align-items: center;
+        }
+      }
+
+      @media screen and (max-width: 440px) {
+        img#unauthorized-access {
+          width: 330px;
+          margin: 20px;
+        }
+
+        div.desc > p.description {
+          max-width: 330px;
+          font-size: 13px;
+        }
+      }
+
       `
     ];
   }
@@ -84,9 +127,9 @@ export default class BackendAIPermissionDeniedView extends BackendAIPage {
   render() {
     // language=HTML
     return html`
-    <div class="horizontal center flex layout center-justified" style="margin:20px;">
-      <img src="/resources/images/401_unauthorized_access.svg" style="width:400px;margin:20px;"/>
-      <div class="vertical layout" style="width:100%;">
+    <div class="page-layout">
+      <img id="unauthorized-access" src="/resources/images/401_unauthorized_access.svg" />
+      <div class="vertical layout desc">
         <div class="title">${_tr('console.UNAUTHORIZEDACCESS')}</div>
         <p class="description">${_tr('console.AdminOnlyPage')}</p>
         <div style="width:auto;">

--- a/src/components/backend-ai-resource-policy-list.ts
+++ b/src/components/backend-ai-resource-policy-list.ts
@@ -115,7 +115,7 @@ export default class BackendAIResourcePolicyList extends BackendAIPage {
         wl-label {
           width: 100%;
           min-width: 60px;
-          font-size: 11px;
+          font-size: 10px; // 11px;
           --label-font-family: Roboto, Noto, sans-serif;
         }
 

--- a/src/components/backend-ai-signup.ts
+++ b/src/components/backend-ai-signup.ts
@@ -91,6 +91,10 @@ export default class BackendAiSignup extends BackendAIPage {
             --mdc-typography-font-family: var(--general-font-family);
           }
 
+          mwc-textfield#id_user_name {
+            margin-bottom: 18px;
+          }
+
           mwc-button.full {
             width: 335px;
           }

--- a/src/components/backend-ai-signup.ts
+++ b/src/components/backend-ai-signup.ts
@@ -426,8 +426,7 @@ export default class BackendAiSignup extends BackendAIPage {
                        value="${this.user_email}" required></mwc-textfield>
           <mwc-textfield type="text" name="user_name" id="id_user_name"
                        maxlength="64" placeholder="${_text('maxLength.64chars')}"
-                       label="${_t("signup.UserName")}" value="${this.user_name}"
-                       validationMessage="${_t("signup.UserNameInputRequired")}"></mwc-textfield>
+                       label="${_t("signup.UserName")}" value="${this.user_name}"></mwc-textfield>
           <mwc-textfield type="text" name="token" id="id_token" maxlength="50"
                        label="${_t("signup.InvitationToken")}"
                        validationMessage="${_t("signup.TokenInputRequired")}" required></mwc-textfield>


### PR DESCRIPTION
After merging this PR, several cosmetic issues will be solved.
You can see the details below.

- make an equal ratio of each input field in creating user dialog.
![스크린샷 2021-01-04 오후 2 02 30](https://user-images.githubusercontent.com/46954439/103503850-06718d80-4e99-11eb-964a-452741515f76.png)
- centered align for each label in resource policy create/update dialog
![policy-font](https://user-images.githubusercontent.com/46954439/103504567-243ff200-4e9b-11eb-8d50-2baca5def261.png)
- centered align for checkbox and text for terminal guide dialog
![스크린샷 2021-01-04 오후 2 02 12](https://user-images.githubusercontent.com/46954439/103504670-74b74f80-4e9b-11eb-8d58-8b37d68834c0.png)
- prevent overlapping from screen height shorter than the drawer menu
![footer-overlapping](https://user-images.githubusercontent.com/46954439/103505419-8863b580-4e9d-11eb-9197-9e2f935f5c2f.png)

- support responsive layout for permission-denied page.
![unauthorized-page](https://user-images.githubusercontent.com/46954439/103505212-0bd0d700-4e9d-11eb-9272-249ac8cfeff3.png)